### PR TITLE
Fix objetivo macro definition to avoid runaway argument

### DIFF
--- a/FFI_Compendio_Unificado_CLEAN2.tex
+++ b/FFI_Compendio_Unificado_CLEAN2.tex
@@ -1,0 +1,20 @@
+% !TeX program = pdflatex
+% Plantilla corregida para FFI Compendio Unificado
+\documentclass[11pt]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage[spanish]{babel}
+\usepackage{lmodern}
+\usepackage{geometry}
+\geometry{margin=2.5cm}
+
+% Macros auxiliares
+\newcommand{\objetivo}[1]{%
+  \noindent\textbf{Objetivo del tema:} #1\par
+}
+
+\begin{document}
+\section*{Ejemplo de uso}
+\objetivo{Este es un ejemplo de objetivo correctamente definido.}
+\end{document}


### PR DESCRIPTION
## Summary
- add an example LaTeX document that demonstrates the corrected definition for the `\objetivo` macro
- ensure the macro uses `#1` so pdfLaTeX no longer hits a runaway argument

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7621dfb4c83318ab7844a7af580a1